### PR TITLE
fix: ユーザー取得のfetchUsersを初回のみ実行

### DIFF
--- a/src/pages/user-list.vue
+++ b/src/pages/user-list.vue
@@ -30,6 +30,8 @@ const { users, loading } = storeToRefs(userStore);
 
 // コンポーネントがマウントされたときにユーザーを取得
 onMounted(() => {
-  userStore.fetchUsers();
+  if (users.value.length === 0) {
+    userStore.fetchUsers();
+  }
 });
 </script>


### PR DESCRIPTION
## 概要
ホームボタン押下ごとにユーザー取得を行い、チャットを行ったユーザーが消えてしまうため、ユーザー取得を初回のみ実行に修正。

Closes #9 